### PR TITLE
Add issuance date to initial vc.

### DIFF
--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -18,10 +18,7 @@ export const createInitialVc = async ({issuer, vc}) => {
   credential.issuer = issuerId;
   credential.issuanceDate = ISOTimeStamp();
   const body = {credential, options};
-  const {data, error} = await issuer.post({json: body});
-  if(error) {
-    throw error;
-  }
+  const {data} = await issuer.post({json: body});
   return data;
 };
 

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -4,11 +4,19 @@
 import {klona} from 'klona';
 import {v4 as uuidv4} from 'uuid';
 
+// Javascript's default ISO timestamp contains milliseconds.
+// This lops off the MS part of the UTC RFC3339 TimeStamp and replaces
+// it with a terminal Z.
+export const ISOTimeStamp = ({date = new Date()} = {}) => {
+  return date.toISOString().replace(/\.\d+Z$/, 'Z');
+};
+
 export const createInitialVc = async ({issuer, vc}) => {
   const {settings: {id: issuerId, options}} = issuer;
   const credential = klona(vc);
   credential.id = `urn:uuid:${uuidv4()}`;
   credential.issuer = issuerId;
+  credential.issuanceDate = ISOTimeStamp();
   const body = {credential, options};
   const {data, error} = await issuer.post({json: body});
   if(error) {


### PR DESCRIPTION
API catalog issuer fails to issue if issuance date doesn't exist, so I've included issuance date in the initial vc.

The PR also removes throwing error within `createInitialVc()` function since the function is mostly called in the before statements of the tests and if it throws, it prevents the execution of tests.