### PR TITLE
Update `package.json` description and `respecConfig` subtitle.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vc-di-ecdsa-test-suite",
   "version": "0.0.1",
-  "description": "Interoperability test suite for ECDSA data integrity cryptosuites.",
+  "description": "Interoperability test suite for ECDSA Data Integrity cryptosuites.",
   "main": "/tests",
   "type": "module",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vc-di-ecdsa-test-suite",
   "version": "0.0.1",
-  "description": "Test suite for ensuring the data integrity of ecdsa-2019 signatures.",
+  "description": "Interoperability test suite for ECDSA data integrity cryptosuites.",
   "main": "/tests",
   "type": "module",
   "directories": {

--- a/respecConfig.json
+++ b/respecConfig.json
@@ -1,7 +1,7 @@
 {
   "specStatus": "unofficial",
   "shortName": "vc-di-ecdsa-test-suite",
-  "subtitle": "Test suite for ensuring the data integrity of ecdsa-2019 signatures.",
+  "subtitle": "Interoperability test suite for ECDSA data integrity cryptosuites.",
   "github": "https://github.com/w3c-ccg/vc-di-ecdsa-test-suite",
   "edDraftURI": "https://w3c-ccg.github.io/vc-di-ecdsa-test-suite",
   "doJsonLd": true,

--- a/respecConfig.json
+++ b/respecConfig.json
@@ -1,7 +1,7 @@
 {
   "specStatus": "unofficial",
   "shortName": "vc-di-ecdsa-test-suite",
-  "subtitle": "Interoperability test suite for ECDSA data integrity cryptosuites.",
+  "subtitle": "Interoperability test suite for ECDSA Data Integrity cryptosuites.",
   "github": "https://github.com/w3c-ccg/vc-di-ecdsa-test-suite",
   "edDraftURI": "https://w3c-ccg.github.io/vc-di-ecdsa-test-suite",
   "doJsonLd": true,


### PR DESCRIPTION
Modifies the description and subtitle to remove reference to the cryptosuite year.

can we change the package name back to `vc-di-ecdsa-test-suite`? 